### PR TITLE
Show migrations when running `truffle test`

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -187,7 +187,7 @@ var Test = {
       Migrate.run(config.with({
         reset: true,
         resolver: resolver,
-        quiet: true
+        quiet: false
       }), function(err) {
         if (err) return reject(err);
         accept();


### PR DESCRIPTION
It was very difficult to debug some issues with tests on a private network that did not display migrations being run implicitly. I recommend setting `quiet: false` here so the user sees an informative display of migrations that are executed during testing.

```
Running migration: 1_initial_migration.js
  Replacing Migrations...
  ... 0x3d8d5d32ef0375d3c0ec50dd86adc8ce0c2288aa013ff1751ecccfb774a9f7f1
```

Note that neither `--quiet=false` or `--quiet=0` work, as `config.with` overrides the value (and the former gives `config.quiet === "false"` rather than `config.quiet == false` anyway).